### PR TITLE
default to python3

### DIFF
--- a/venvwrapper
+++ b/venvwrapper
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 currentDir=$PWD
+PYTHON=${PYTHON:=python3}
 
 helpmenu () {
 	echo -e "\nVerwendung:  venvwrapper <Operation> [...]\nOperationen:
@@ -30,11 +31,11 @@ create () {
 	cd
 	if [ -d .venv ]; then
 		cd .venv
-		python -m venv $1
+		$PYTHON -m venv $1
 		echo "The virtual enviroment $1 was created successfully!"
 	else
 		mkdir .venv
-		python -m venv $1
+		$PYTHON -m venv $1
 		echo "The virtual enviroment $1 was created successfully!"
 	fi
 	open $1


### PR DESCRIPTION
Solves issue #1,
defaulting to `python3` and allowing to set a specific python executable:
```bash
PYTHON=/usr/bin/python3.6 venvwrapper --create ...
```